### PR TITLE
Change TS exaples to use port 4318

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -67,7 +67,7 @@ npm install --save-dev \ # or `pnpm add -D` or `yarn add -D`
 
 ## 🔧 Configuration Overview
 
-The example utilizes the OTLP HTTP exporter by default, with the endpoint configurable via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. If not set, it defaults to `http://localhost:4317`.
+The example utilizes the OTLP HTTP exporter by default, with the endpoint configurable via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. If not set, it defaults to `http://localhost:4318`.
 
 ## 🧪 Generic OpenTelemetry Setup
 
@@ -192,14 +192,14 @@ The automatic instrumentation detects and instruments:
 
 ## 📈 Exporting Telemetry Data
 
-The setup is configured to export telemetry data using the OTLP gRPC protocol. Ensure that your OpenTelemetry Collector or backend is set up to receive data at the specified endpoint (`http://localhost:4317` by default).
+The setup is configured to export telemetry data using the OTLP HTTP protocol. Ensure that your OpenTelemetry Collector or backend is set up to receive data at the specified endpoint (`http://localhost:4318` by default).
 
 ## 🧪 Example Usage
 
 Set the OTLP Endpoint (if different from default):
 
 ```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-otel-collector:4317"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-otel-collector:4318"
 ```
 
 ### HTTP Server Application

--- a/typescript/client/otel-client.ts
+++ b/typescript/client/otel-client.ts
@@ -24,7 +24,7 @@ const serviceName = "example-client"; // replace with your service name
 // Next.js use process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT and process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_BEARER_TOKEN
 // Vite use import.meta.env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT and import.meta.env.VITE_OTEL_EXPORTER_OTLP_BEARER_TOKEN
 const otlpEndpoint =
-  process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://localhost:4317";
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://localhost:4318";
 const otlpEndpointBearerToken = process.env.OTEL_EXPORTER_OTLP_BEARER_TOKEN;
 
 const authHeader = otlpEndpointBearerToken

--- a/typescript/server/otel-server.ts
+++ b/typescript/server/otel-server.ts
@@ -17,7 +17,7 @@ import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 const serviceName = "example-service"; // replace with your service name
 
 const otlpEndpoint =
-  process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://localhost:4317";
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://localhost:4318";
 const otlpEndpointBearerToken = process.env.OTEL_EXPORTER_OTLP_BEARER_TOKEN;
 
 const authHeader = otlpEndpointBearerToken


### PR DESCRIPTION
The otel collector we use for evals expects port 4317 for grpc and 4318 for http. Evaluation was failing because of this.

See: https://jenkins.observeinc.com/job/master-periodic-instrumentation-eval/88