### PR TITLE
Fix Go OpenTelemetry setup to work with Observe requirements

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -3,36 +3,33 @@ module example.com/m/v2
 go 1.24
 
 require (
-	go.opentelemetry.io/contrib/bridges/otelslog v0.12.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
-	go.opentelemetry.io/otel v1.37.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.10.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0
-	go.opentelemetry.io/otel/log v0.13.0
-	go.opentelemetry.io/otel/metric v1.37.0
-	go.opentelemetry.io/otel/sdk v1.36.0
-	go.opentelemetry.io/otel/sdk/log v0.10.0
-	go.opentelemetry.io/otel/sdk/metric v1.36.0
-	go.opentelemetry.io/otel/trace v1.37.0
+	go.opentelemetry.io/contrib/bridges/otelslog v0.13.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
+	go.opentelemetry.io/otel/log v0.14.0
+	go.opentelemetry.io/otel/metric v1.38.0
+	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel/sdk/log v0.14.0
+	go.opentelemetry.io/otel/sdk/metric v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
 )
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
-	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250519155744-55703ea1f237 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237 // indirect
-	google.golang.org/grpc v1.72.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
+	golang.org/x/net v0.43.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/text v0.28.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
+	google.golang.org/grpc v1.75.0 // indirect
+	google.golang.org/protobuf v1.36.8 // indirect
 )


### PR DESCRIPTION
Updates the Go OpenTelemetry implementation to work with just 2 environment variables, matching the TypeScript examples and making it compatible with Observe and other OTLP-compatible backends.

🔧 Changes Made

Core Implementation:

✅ Switched from gRPC to HTTP exporters for all telemetry types
✅ Added bearer token authentication via OTEL_EXPORTER_OTLP_BEARER_TOKEN
✅ Added required x-observe-target-package headers for proper telemetry routing
✅ Updated default endpoint from localhost:4317 (gRPC) to http://localhost:4318 (HTTP)
✅ Added proper URL paths (/v1/traces, /v1/metrics, /v1/logs)

Dependencies:

✅ Added HTTP exporter packages: otlptracehttp, otlpmetrichttp, otlploghttp
✅ Cleaned up unused gRPC dependencies with go mod tidy

Documentation:

✅ Updated README with clear environment variable requirements
✅ Added Quick Start guide with usage examples
✅ Updated installation instructions to use HTTP exporters

🎯 Environment Variables

Consumers now only need to set these 2 environment variables:
```
export OTEL_EXPORTER_OTLP_ENDPOINT=https://185003257558.collect.observeinc.com/v2/otel
export OTEL_EXPORTER_OTLP_BEARER_TOKEN=<token>
```

✅ Headers Automatically Included
The implementation automatically adds:
* Authorization: Bearer <token> (when OTEL_EXPORTER_OTLP_BEARER_TOKEN is set)
* x-observe-target-package: Tracing|Metrics|Logs (depending on telemetry type)

🔍 Why No Content-Type: application/x-protobuf Header?
Unlike the TypeScript implementation, the Go version doesn't need the Content-Type: application/x-protobuf header because:
* TypeScript: Uses separate exporters (@opentelemetry/exporter-metrics-otlp-proto for protobuf vs @opentelemetry/exporter-trace-otlp-http for JSON), requiring explicit Content-Type headers
* Go: Uses unified HTTP exporters (otlpmetrichttp, otlptracehttp, otlploghttp) that automatically send protobuf over HTTP (as documented: "using HTTP with protobuf payloads")

Both implementations achieve the same result (efficient protobuf transmission), just with different approaches.

🔄 Breaking Changes
Endpoint format changed: From localhost:4317 (gRPC) to http://localhost:4318 (HTTP)
Exporter types changed: From gRPC to HTTP exporters (internal change, same API)

🧪 Testing
✅ Code compiles successfully
✅ All imports resolved correctly
✅ Consistent with TypeScript implementation patterns

📁 Files Changed
* go/otel.go - Core implementation updates
* go/README.md - Documentation updates
* go/go.mod - Dependency updates
* go/go.sum - Dependency checksums